### PR TITLE
Set up mailgun for sending emails

### DIFF
--- a/server/bootstrap.js
+++ b/server/bootstrap.js
@@ -3,7 +3,7 @@ Meteor.startup(function () {
     var smtp = {
         username: Meteor.settings.mail.user,   // eg: server@gentlenode.com
         password: Meteor.settings.mail.password, // eg: 3eeP1gtizk5eziohfervU
-        server: 'smtp.1and1.com',  // eg: mail.gandi.net
+        server: 'smtp.mailgun.org',  // eg: mail.gandi.net
         port: 587
     };
     process.env.MAIL_URL = 'smtp://' + encodeURIComponent(smtp.username) + ':' + encodeURIComponent(smtp.password) + '@' + encodeURIComponent(smtp.server) + ':' + smtp.port;

--- a/server/methods.js
+++ b/server/methods.js
@@ -174,6 +174,7 @@ Meteor.methods({
 
     'createBrisboxer': function (doc) {
         check(doc, SchemaInscription);
+        var outerMethod = this;
         Meteor.call('createBrisboxerNoRole', doc, function (err, userId) {
             if (err) { // TODO: Simulate transaction and delete inscription form
                 console.log(err);
@@ -184,7 +185,7 @@ Meteor.methods({
                         verified: false
                     }
                 });
-                this.unblock();
+                outerMethod.unblock();
                 Accounts.sendVerificationEmail(userId);
             }
         });


### PR DESCRIPTION
Tras probar distintas soluciones, como contactar con 1&1, sin éxito para tratar de resolver el envío de correos desde la dirección hello@brisbox.com, se ha hecho uso de mailgun y gmail para enviar los correos desde dicha dirección.
Los detalles de lo que se ha hecho se pueden consultar en https://simplyian.com/2015/01/07/Hacking-GMail-to-use-custom-domains-for-free/

Hay un límite de 10k correos al mes, lo cual no se prevé sea un problema.
