### PR TITLE
Change profile image

### DIFF
--- a/client/css/brisboxer-details/brisboxer-details.css
+++ b/client/css/brisboxer-details/brisboxer-details.css
@@ -1,3 +1,16 @@
 .detail-buttons{
     margin: 30px 0;
 }
+
+.spinner-orange, .spinner-orange-only {
+    border-color: #ef6c00 !important;
+}
+
+.circle {
+    border-radius: 30% !important;
+}
+
+.autoMargin {
+    margin-left: auto;
+    margin-right: auto;
+}

--- a/client/js/brisboxer-details/brisboxer-details.js
+++ b/client/js/brisboxer-details/brisboxer-details.js
@@ -119,5 +119,76 @@ Template.brisboxerDetails.events({
     'click #cancel_button': function (event) {
         event.preventDefault();
         Session.set('editBrisboxer', false);
-    }
+    },
+    'change #upload_image': function(event, template) {
+        event.preventDefault();
+        $('#ImageSync').addClass('active');
+        if (this.profile.image != null) {
+            Images.remove({_id:this.profile.image}, function (err, result) {
+                if (err) {
+                    console.log("Error removing oldImage");
+                    console.log(err);
+                }
+            });
+        }
+        FS.Utility.eachFile(event, function(file) {
+            Images.insert(file, function (err, fileObj) {
+                if (err){
+                    console.log("Error inserting newImage");
+                    console.log(err);
+                } else {
+                    var cursor = Images.find(fileObj._id);
+                    var liveQuery = cursor.observe({
+                        changed: function(newImage, oldImage) {
+                            if (newImage.isUploaded()) {
+                                liveQuery.stop();
+                                var imageId = fileObj._id;
+                                var id = Meteor.userId();
+                                Meteor.setTimeout(timeout, 3000);
+                                function timeout(){
+
+                                }
+                                Meteor.call('updateProfileImage', imageId, id, function(err){
+                                    if (err){
+                                        console.log("Error updating profileImage");
+                                        console.log(err);
+                                    } else {
+                                        $('#ImageSync').removeClass('active');
+                                    };
+                                });
+                            }
+                        }
+                    })
+                }
+            });
+        });
+    },
+    'click #remove_image': function (event) {
+        event.preventDefault();
+        $('#ImageSync').addClass('active');
+        if (this.profile.image != null) {
+            Images.remove({_id:this.profile.image}, function (err, result) {
+                if (err) {
+                    console.log("Error removing oldImage");
+                    console.log(err);
+                }
+            });
+        }
+        var imageId = null;
+        var id = Meteor.userId();
+        Meteor.setTimeout(timeout, 3000);
+        function timeout(){
+            var id = 20;
+        }
+        Meteor.call('updateProfileImage', imageId, id, function(err){
+            if (err){
+                console.log("Error updating profileImage");
+                console.log(err);
+            } else {
+                $('#ImageSync').removeClass('active');
+            };
+        });
+
+    },
+
 });

--- a/client/views/partials/brisboxer-details/brisboxer-details.html
+++ b/client/views/partials/brisboxer-details/brisboxer-details.html
@@ -12,12 +12,6 @@
                     {{#if isCurrentUser _id}}
                         {{#if editBrisboxer}}
                             <div class="row valign-wrapper">
-                                <div class="file-field input-field autoMargin">
-                                    <div class="waves-effect waves-light btn orange darken-3 z-depth-1 bold">
-                                        <span>{{_ "brisboxer_details_change_image"}}</span>
-                                        <input type="file" id="upload_image">
-                                    </div>
-                                </div>
                                 <div class="preloader-wrapper" id="ImageSync">
                                     <div class="spinner-layer spinner-orange-only">
                                         <div class="circle-clipper left">
@@ -29,8 +23,14 @@
                                     </div>
                                     </div>
                                 </div>
+                                <div class="file-field input-field">
+                                    <div class="waves-effect waves-light btn orange darken-3 z-depth-1 bold">
+                                        <span>{{_ "brisboxer_details_change_image"}}</span>
+                                        <input type="file" id="upload_image">
+                                    </div>
+                                </div>
                                 <button id="remove_image" type="button"
-                                        class="waves-effect waves-light btn orange darken-3 z-depth-1 bold input-field autoMargin">
+                                        class="waves-effect waves-light btn-flat bold input-field">
                                     {{_ "brisboxer_details_remove_image"}}
                                 </button>
                             </div>
@@ -123,7 +123,7 @@
                                 class="waves-effect waves-light btn orange darken-3 z-depth-1 bold">{{_ "brisboxer_details_save"}}
                         </button>
                         <button id="cancel_button" type="button"
-                                class="waves-effect waves-light btn orange darken-3 z-depth-1 bold">{{_ "brisboxer_details_cancel"}}
+                                class="waves-effect waves-light btn-flat bold">{{_ "brisboxer_details_cancel"}}
                         </button>
                     {{else}}
                         <button id="edit_button" type="button"

--- a/client/views/partials/brisboxer-details/brisboxer-details.html
+++ b/client/views/partials/brisboxer-details/brisboxer-details.html
@@ -4,9 +4,38 @@
 
         {{#if exists}}
             <div class="row">
-                <div class="col s12 m6 l4 valign-wrapper">
-                    <img src={{imageProfile}} class="circle" height="auto" width="90%"
-                         style="margin-right: auto;margin-left: auto;"/>
+                <div class="col s12 m6 l4">
+                    <div class="row valign-wrapper">
+                        <img src={{imageProfile}} class="circle" height="auto" width="90%"
+                             style="margin-right: auto;margin-left: auto;max-width: 345px;max-height: 387px"/>
+                    </div>
+                    {{#if isCurrentUser _id}}
+                        {{#if editBrisboxer}}
+                            <div class="row valign-wrapper">
+                                <div class="file-field input-field autoMargin">
+                                    <div class="waves-effect waves-light btn orange darken-3 z-depth-1 bold">
+                                        <span>{{_ "brisboxer_details_change_image"}}</span>
+                                        <input type="file" id="upload_image">
+                                    </div>
+                                </div>
+                                <div class="preloader-wrapper" id="ImageSync">
+                                    <div class="spinner-layer spinner-orange-only">
+                                        <div class="circle-clipper left">
+                                            <div class="circle"></div>
+                                        </div><div class="gap-patch">
+                                        <div class="circle"></div>
+                                    </div><div class="circle-clipper right">
+                                        <div class="circle"></div>
+                                    </div>
+                                    </div>
+                                </div>
+                                <button id="remove_image" type="button"
+                                        class="waves-effect waves-light btn orange darken-3 z-depth-1 bold input-field autoMargin">
+                                    {{_ "brisboxer_details_remove_image"}}
+                                </button>
+                            </div>
+                        {{/if}}
+                    {{/if}}
                 </div>
                 <div class="col s12 m6 l8" style="margin-top: 55px;">
                     <div class="row valign-wrapper">

--- a/lib/collections/image-profile.js
+++ b/lib/collections/image-profile.js
@@ -15,5 +15,8 @@ Images.allow({
     },
     download: function (userId) {
         return true;
+    },
+    remove: function (userId) {
+        return true;
     }
 });

--- a/lib/i18n/en.i18n.json
+++ b/lib/i18n/en.i18n.json
@@ -462,6 +462,8 @@
   "brisboxer_details_edit": "Edit profile",
   "brisboxer_details_comments": "What our customers say",
   "brisboxer_details_empty_assessment": "The brisboxer doesn't have any assessment yet.",
+  "brisboxer_details_change_image": "Change",
+  "brisboxer_details_remove_image": "Remove",
 
   "monthly_stats": "Monthly stats for",
   "monthly_stats_title": "Monthly stats",

--- a/lib/i18n/es.i18n.json
+++ b/lib/i18n/es.i18n.json
@@ -456,6 +456,8 @@
   "brisboxer_details_edit": "Editar perfil",
   "brisboxer_details_comments": "Lo que dicen nuestros clientes",
   "brisboxer_details_empty_assessment": "El brisboxer no ha recibido ninguna valoración todavía.",
+  "brisboxer_details_change_image": "Cambiar",
+  "brisboxer_details_remove_image": "Eliminar",
 
   "monthly_stats": "Estadística mensual de",
   "monthly_stats_title": "Estadística mensual",

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -106,7 +106,7 @@ Router.route('/apply', function () {
 }, {
     name: 'join-us',
     waitOn: function () {
-        return Meteor.subscribe('images');
+        return subs.subscribe('images');
     }
 });
 
@@ -239,7 +239,7 @@ Router.route('/brisboxer/:_id', {
     },
     name: 'brisboxer-details',
     waitOn: function () {
-        return subs.subscribe("brisboxer", this.params._id);
+        return subs.subscribe[("brisboxer", this.params._id), subs.subscribe('images')];
     }
 });
 Router.route('/brisboxer/:_id/monthly-stats', {

--- a/server/methods.js
+++ b/server/methods.js
@@ -324,7 +324,13 @@ Meteor.methods({
             totalHours: captainHours + normalHours,
             earned: earned
         };
+    },
+    'updateProfileImage': function (imageId, id) {
+        Meteor.users.update({_id: id}, {
+            $set: {
+                "profile.image":imageId
+            }
+        });
     }
-
 })
 ;


### PR DESCRIPTION
## Resumen:

Se ha implantado la posibilidad de modificar la imagen de perfil del brisboxer. Al cambiarse se elimina la anterior de la bd, de forma que se palia parcialmente la incidencia existente con la saturación de subidas de imagenes desde el formulario de inscripción (#190).
## Pruebas a realizar:

Las pruebas a realizar se situan todas en la vista de detalles del brisboxer (perfil):
- Comprobar que al clickar en editar perfil, se habilitan las opciones de cambiar imagen y eliminarla.
- Comprobar que seleccionar una imagen, esta se guarda correctamente. Para ello seleccionamos una imagen nueva en la opción 'Cambiar'. Después de esto podemos abandonar la sesión y volver a entrar para comprobar con mayor seguridad que se ha realizado el cambio correctamente.
- Comprobar que al darle click a 'Eliminar', la imagen actual del perfil se elimina, cogiendose como imagen de perfil la que brisbox pone por defecto (/placeholder.png).
## Incidencias:

Se ha trabajado con el paquete Collection FS y se palia en cierta medida le problema que hay en el formulario de inscripción. Implantando esta misma forma de subir imagenes en el formulario de inscripción se podría corregir el problema completamente, y solo se guardarían una imagen por cada brisboxer.
