### PR TITLE
Changed the constraint of hours to cancel an order up 24h

### DIFF
--- a/client/js/order_dashboard/order_dashboard.js
+++ b/client/js/order_dashboard/order_dashboard.js
@@ -74,9 +74,9 @@ Template.registerHelper("orderDay", function (date) {
 });
 Template.registerHelper("orderCancel", function (date) {
     var hoy = new Date();
-    var diaPedidoSub12H = new Date();
-    diaPedidoSub12H.setTime(date.getTime() - 43200000);
-    return hoy.getTime() - diaPedidoSub12H.getTime() < 0;
+    var diaPedidoSub24H = new Date();
+    diaPedidoSub24H.setTime(date.getTime() - 86400000);
+    return hoy.getTime() - diaPedidoSub24H.getTime() < 0;
 });
 Template.order_dashboard.events({
     'click #cancel': function (event) {

--- a/lib/i18n/en.i18n.json
+++ b/lib/i18n/en.i18n.json
@@ -424,7 +424,7 @@
   "email_order_registered_title": "Thank you, %s.",
   "email_order_registered_first_p": "Your order has been sucessfully registered. We will notify you as soon as the requested number of brisboxers has been met.",
   "email_order_registered_second_p": "To access the dashboard and track the status of your order, click <a href='%s'>here</a>.",
-  "email_order_registered_third_p": "You can cancel your order up to 12h. before it takes place by visiting <a href='%s'>this link</a> and using the following code: ",
+  "email_order_registered_third_p": "You can cancel your order up to 24h. before it takes place by visiting <a href='%s'>this link</a> and using the following code: ",
   "order-form_location": "Enter a location",
   "order-form_validate-zip": "Insert a ZIP Code",
   "order-form_validate-addressLoading": "Insert a loading address",

--- a/lib/i18n/es.i18n.json
+++ b/lib/i18n/es.i18n.json
@@ -415,7 +415,7 @@
   "email_order_registered_title": "Gracias, %s.",
   "email_order_registered_first_p": "Tu pedido ha sido registrado en el sistema. Tan pronto como el número de brisboxers solicitado haya sido cubierto te lo notificaremos.",
   "email_order_registered_second_p": "Para acceder al panel de control de tu pedido y llevar un seguimiento de él, haz click <a href='%s'>aquí</a>.",
-  "email_order_registered_third_p": "Puedes cancelar tu pedido con hasta 12h. de antelación desde <a href='%s'>este enlace</a> introduciendo el siguiente código: ",
+  "email_order_registered_third_p": "Puedes cancelar tu pedido con hasta 24h. de antelación desde <a href='%s'>este enlace</a> introduciendo el siguiente código: ",
   "message-not_found": "Parece que no podemos encontrar la página que está buscando.",
   "title-not_found": "Oops! Error 404",
   "order-form_location": "Introduce una ubicación",


### PR DESCRIPTION
## Resumen:

Se ha cambiado la restricción de horas previas para cancelar un pedido. Ahora se puede cancelar un pedido con hasta 24h. de antelación (#206).
## Pruebas a realizar:
- Probar la nueva regla de negocio en los dos casos posibles: cancelar un pedido al que aun le resten más de 24h para su celebración (debe permitirlo) y cancelar un pedido al que le queden menos de 24h para su celebración (no debe aparecer la opción). 
- Comprobar que en el email de registro del pedido se indica correctamente que el código de cancelación sirve para cancelar un pedido con hasta 24h. de antelación.
## Incidencias:

Ninguna
