### PR TITLE
Accept extra hours

### DIFF
--- a/client/js/accept-extra-hours/AcceptExtraHoursController.js
+++ b/client/js/accept-extra-hours/AcceptExtraHoursController.js
@@ -1,0 +1,17 @@
+CancelOrderController = RouteController.extend({
+    orderCancel: function () {
+        var idCodificado = this.params.id;
+        Meteor.call('acceptExtraHours', idCodificado, function( error, response ) {
+            if (response == "ACCEPT_EXTRA_HOURS") {
+                sessionStorage.setItem("id", idCodificado);
+                Router.go('AcceptExtraHours');
+            }
+            if (response == "ALREADY_CHOSED") {
+                Router.go('AcceptExtraHoursFailed');
+            }
+            if (response == "NOTFOUND") {
+                Router.go("ExtraHoursNotFound");
+            }
+        });
+    }
+});

--- a/client/js/accept-extra-hours/AcceptExtraHoursController.js
+++ b/client/js/accept-extra-hours/AcceptExtraHoursController.js
@@ -1,9 +1,9 @@
 CancelOrderController = RouteController.extend({
     orderCancel: function () {
         var idCodificado = this.params.id;
-        Meteor.call('acceptExtraHours', idCodificado, function( error, response ) {
+        Meteor.call('acceptExtraHoursController', idCodificado, function( error, response ) {
             if (response == "ACCEPT_EXTRA_HOURS") {
-                sessionStorage.setItem("id", idCodificado);
+                sessionStorage.setItem("extraHoursId", idCodificado);
                 Router.go('AcceptExtraHours');
             }
             if (response == "ALREADY_CHOSED") {

--- a/client/js/accept-extra-hours/accept-extra-hours.js
+++ b/client/js/accept-extra-hours/accept-extra-hours.js
@@ -1,3 +1,37 @@
 /**
  * Created by Fran Viejo on 10/05/2016.
  */
+
+Template.OrderCancel.events({
+
+    'click #accept': function (event) {
+        event.preventDefault();
+        var idDecodifidado = this._id;
+        var orderId = this.orderId;
+        Meteor.call('acceptExtraHours', idDecodifidado, function (error, response){
+            if (error) {
+                Router.go('acceptExtraHoursFailed');
+            } else {
+                sessionStorage.removeItem("extraHoursId");
+                Router.go('order_dashboard', {_id: orderId});
+            }
+        });
+    },
+    'click #reject': function (event) {
+        event.preventDefault();
+        var idDecodifidado = this._id;
+        var orderId = this.orderId;
+        Meteor.call('rejectExtraHours', idDecodifidado, function (error, response){
+            if (error) {
+                Router.go('acceptExtraHoursFailed');
+            } else {
+                sessionStorage.removeItem("extraHoursId");
+                Router.go('order_dashboard', {_id: orderId});
+            }
+        });
+    },
+    'click #dashboard': function (event) {
+        event.preventDefault();
+        Router.go('order_dashboard', {_id: this.orderId});
+    }
+});

--- a/client/js/accept-extra-hours/accept-extra-hours.js
+++ b/client/js/accept-extra-hours/accept-extra-hours.js
@@ -1,0 +1,3 @@
+/**
+ * Created by Fran Viejo on 10/05/2016.
+ */

--- a/client/js/accept-extra-hours/accept-extra-hours.js
+++ b/client/js/accept-extra-hours/accept-extra-hours.js
@@ -2,7 +2,7 @@
  * Created by Fran Viejo on 10/05/2016.
  */
 
-Template.OrderCancel.events({
+Template.acceptExtraHours.events({
 
     'click #accept': function (event) {
         event.preventDefault();
@@ -35,3 +35,14 @@ Template.OrderCancel.events({
         Router.go('order_dashboard', {_id: this.orderId});
     }
 });
+
+Template.acceptExtraHours.onRendered(function(){
+    var self = this;
+
+    this.autorun(function (a) {
+        var data = Template.currentData(self.view);
+        if (data == "extraHoursNotFound"){
+            Router.go('extraHoursNotFound');
+        }
+    });
+})

--- a/client/views/partials/accept-extra-hours/accept-extra-hours-failed.html
+++ b/client/views/partials/accept-extra-hours/accept-extra-hours-failed.html
@@ -2,10 +2,10 @@
     <div class="container">
         <div class="section scrollspy">
             <div class="row">
-                <h4 class="header">{{_ "order_deleted_failed"}}</h4>
+                <h4 class="header">{{_ "extra_hours_failed"}}</h4>
             </div>
             <div class="row">
-                <p>{{_ "order_deleted_failed_body"}}</p>
+                <p>{{_ "extra_hours_failed_body"}}</p>
             </div>
             <div class="row">
                <a href="/">{{_ "return_to_main_page"}}</a>

--- a/client/views/partials/accept-extra-hours/accept-extra-hours-failed.html
+++ b/client/views/partials/accept-extra-hours/accept-extra-hours-failed.html
@@ -1,0 +1,15 @@
+<template name="acceptExtraHoursFailed">
+    <div class="container">
+        <div class="section scrollspy">
+            <div class="row">
+                <h4 class="header">{{_ "order_deleted_failed"}}</h4>
+            </div>
+            <div class="row">
+                <p>{{_ "order_deleted_failed_body"}}</p>
+            </div>
+            <div class="row">
+               <a href="/">{{_ "return_to_main_page"}}</a>
+            </div>
+        </div>
+    </div>
+</template>

--- a/client/views/partials/accept-extra-hours/accept-extra-hours.html
+++ b/client/views/partials/accept-extra-hours/accept-extra-hours.html
@@ -1,0 +1,27 @@
+<template name="acceptExtraHours">
+    <div class="container">
+        <div class="section scrollspy">
+            <div class="row">
+                <h4 class="header">{{_ "extra_hours_header"}}</h4>
+            </div>
+            <div class="row">
+                <p>{{_ "extra_hours_choose"}}</p>
+            </div>
+            <div class="row">
+                <div class="input-field col s12 m6">
+                    <input id="cancelationCode" type="text" required class="form-control col s12 m6">
+                    <label id="label_cancelation" for="cancelationCode"
+                           class=" col s6 m6">{{_ "cancel-form-code"}}</label>
+                </div>
+            </div>
+            <div class="row">
+                <div class="input-field col s12 m6">
+                    <button type="button" id="cancel"
+                            class="btn btn-primary waves-button-input orange darken-3">{{_ "cancel-submit"}}</button>
+                    <button type="button" id="dashboard"
+                            class="waves-effect waves-orange waves-ripple btn-flat">{{_ "go_back"}}</button>
+                </div>
+            </div>
+        </div>
+    </div>
+</template>

--- a/client/views/partials/accept-extra-hours/accept-extra-hours.html
+++ b/client/views/partials/accept-extra-hours/accept-extra-hours.html
@@ -9,18 +9,15 @@
             </div>
             <div class="row">
                 <div class="input-field col s12 m6">
-                    <input id="cancelationCode" type="text" required class="form-control col s12 m6">
-                    <label id="label_cancelation" for="cancelationCode"
-                           class=" col s6 m6">{{_ "cancel-form-code"}}</label>
+                    <button type="button" id="accept"
+                            class="btn btn-primary waves-button-input orange darken-3"><i class="material-icons left">alarm_on</i>{{_ "extra_hours_accept" hours=extra_hours}}</button>
+                    <button type="button" id="reject"
+                            class="btn btn-primary waves-button-input orange darken-3"><i class="material-icons left">alarm_off</i>{{_ "extra_hours_deny"}}</button>
                 </div>
             </div>
             <div class="row">
-                <div class="input-field col s12 m6">
-                    <button type="button" id="cancel"
-                            class="btn btn-primary waves-button-input orange darken-3">{{_ "cancel-submit"}}</button>
-                    <button type="button" id="dashboard"
-                            class="waves-effect waves-orange waves-ripple btn-flat">{{_ "go_back"}}</button>
-                </div>
+                <button type="button" id="dashboard"
+                        class="waves-effect waves-orange waves-ripple btn-flat">{{_ "go_back"}}</button>
             </div>
         </div>
     </div>

--- a/client/views/partials/accept-extra-hours/extra-hours-notFound.html
+++ b/client/views/partials/accept-extra-hours/extra-hours-notFound.html
@@ -1,0 +1,17 @@
+<template name="extraHoursNotFound">
+    <div class="container">
+        <div class="section scrollspy">
+            <div class="row">
+                <h4 class="header">{{_ "order_not_found"}}</h4>
+            </div>
+            <div class="row">
+                <p>{{_ "order_not_found_body1"}}<a
+                        href="mailto:hello@brisbox.com">{{_ "send_mail_to_Brisbox"}}</a>{{_ "order_not_found_body2"}} <a
+                        href="/contact-us">{{_ "contact_us_header"}}</a> {{_ "order_not_found_body3"}}</p>
+            </div>
+            <div class="row">
+                <a href="/">{{_ "return_to_main_page"}}</a>
+            </div>
+        </div>
+    </div>
+</template>

--- a/client/views/partials/accept-extra-hours/extra-hours-notFound.html
+++ b/client/views/partials/accept-extra-hours/extra-hours-notFound.html
@@ -2,10 +2,10 @@
     <div class="container">
         <div class="section scrollspy">
             <div class="row">
-                <h4 class="header">{{_ "order_not_found"}}</h4>
+                <h4 class="header">{{_ "extra_hours_not_found"}}</h4>
             </div>
             <div class="row">
-                <p>{{_ "order_not_found_body1"}}<a
+                <p>{{_ "extra_hours_found_body1"}}<a
                         href="mailto:hello@brisbox.com">{{_ "send_mail_to_Brisbox"}}</a>{{_ "order_not_found_body2"}} <a
                         href="/contact-us">{{_ "contact_us_header"}}</a> {{_ "order_not_found_body3"}}</p>
             </div>

--- a/client/views/partials/accept-extra-hours/extra-hours-notFound.html
+++ b/client/views/partials/accept-extra-hours/extra-hours-notFound.html
@@ -5,6 +5,7 @@
                 <h4 class="header">{{_ "extra_hours_not_found"}}</h4>
             </div>
             <div class="row">
+                <p>{{_ "extra_hours_not_found_body0"}}</p>
                 <p>{{_ "extra_hours_found_body1"}}<a
                         href="mailto:hello@brisbox.com">{{_ "send_mail_to_Brisbox"}}</a>{{_ "order_not_found_body2"}} <a
                         href="/contact-us">{{_ "contact_us_header"}}</a> {{_ "order_not_found_body3"}}</p>

--- a/lib/i18n/en.i18n.json
+++ b/lib/i18n/en.i18n.json
@@ -496,6 +496,10 @@
   //Accept extra hours
   "extra_hours_header": "Accept extra hours",
   "extra_hours_choose": "Please, choose if you want accept the required extra hours.",
-  "extra_hours_accept": "Accept",
-  "extra_hours_deny": "Deny"
+  "extra_hours_accept": "Accept __hours__ extra hours",
+  "extra_hours_deny": "Deny",
+  "extra_hours_failed": "Again here?",
+  "extra_hours_failed_body": "An error occurred while accepting extra hours. The decision about this extra hours has already been done",
+  "extra_hours_not_found": "Extra hours request not found",
+  "extra_hours_found_body1": "Your extra hours request isn't found on the system. If you thing that was an error, please contact with Brisbox Team. If you have an email client, click on "
 }

--- a/lib/i18n/en.i18n.json
+++ b/lib/i18n/en.i18n.json
@@ -491,6 +491,11 @@
   "finished_Order": "That's all, folks!",
   "finished_Order_body": "Hopefully it was a satisfactory experience.",
   "finished_Order_assessment": "In order to improve our services, we would like you to take a moment and rate our brisboxers. We really appreciate your feedback.",
-  "assess_them": "Assess brisboxers"
+  "assess_them": "Assess brisboxers",
 
+  //Accept extra hours
+  "extra_hours_header": "Accept extra hours",
+  "extra_hours_choose": "Please, choose if you want accept the required extra hours.",
+  "extra_hours_accept": "Accept",
+  "extra_hours_deny": "Deny"
 }

--- a/lib/i18n/en.i18n.json
+++ b/lib/i18n/en.i18n.json
@@ -501,5 +501,6 @@
   "extra_hours_failed": "Again here?",
   "extra_hours_failed_body": "An error occurred while accepting extra hours. The decision about this extra hours has already been done",
   "extra_hours_not_found": "Extra hours request not found",
-  "extra_hours_found_body1": "Your extra hours request isn't found on the system. If you thing that was an error, please contact with Brisbox Team. If you have an email client, click on "
+  "extra_hours_not_found_body0": "Your extra hours request isn't found on the system. This would be because you have not accessed from link adjunt to email sent before or you have already answered to this request.",
+  "extra_hours_found_body1": "If you thing that was an error, please contact with Brisbox Team. If you have an email client, click on "
 }

--- a/lib/i18n/es.i18n.json
+++ b/lib/i18n/es.i18n.json
@@ -494,5 +494,6 @@
   "extra_hours_failed": "¿Otra vez por aquí?",
   "extra_hours_failed_body": "Ha ocurrido un error en la aceptación de horas extras. La aceptación o rechazo de estas horas extras ya ha sido realizada.",
   "extra_hours_not_found": "Petición de horas extras no encontrada",
-  "extra_hours_found_body1": "Tu petición de horas extras no ha sido encontrada en el sistema. Si cree que ha sido un error, por favor póngase en contacto con el equipo de Brisbox. Si dispone de un cliente de correo, pulse en "
+  "extra_hours_not_found_body0": "Tu petición de horas extras no ha sido encontrada en el sistema. Puede deberse a que no ha accedido desde el enlace facilitado en el correo o que ya haya respondido a esta petición.",
+  "extra_hours_found_body1": "Si cree que ha sido un error, por favor póngase en contacto con el equipo de Brisbox. Si dispone de un cliente de correo, pulse en "
 }

--- a/lib/i18n/es.i18n.json
+++ b/lib/i18n/es.i18n.json
@@ -484,5 +484,11 @@
   "finished_Order": "¡Eso es todo, amigos!",
   "finished_Order_body": "Esperamos que haya sido una experiencia satisfactoria.",
   "finished_Order_assessment": "Para mejorar nuestro servicio, nos gustaría que dedicaras un momento a puntuar a nuestros brisboxers. Tenemos muy en cuenta tu opinión.",
-  "assess_them": "Valorar brisboxers"
+  "assess_them": "Valorar brisboxers",
+
+  //Accept extra hours
+  "extra_hours_header": "Aceptar horas extras",
+  "extra_hours_choose": "Por favor, seleccione si quiere aceptar las horas extras propuestas.",
+  "extra_hours_accept": "Aceptar",
+  "extra_hours_deny": "Rechazar"
 }

--- a/lib/i18n/es.i18n.json
+++ b/lib/i18n/es.i18n.json
@@ -488,7 +488,11 @@
 
   //Accept extra hours
   "extra_hours_header": "Aceptar horas extras",
-  "extra_hours_choose": "Por favor, seleccione si quiere aceptar las horas extras propuestas.",
-  "extra_hours_accept": "Aceptar",
-  "extra_hours_deny": "Rechazar"
+  "extra_hours_choose": "Por favor, indique si quiere aceptar las horas extras propuestas.",
+  "extra_hours_accept": "Aceptar __hours__ horas extras",
+  "extra_hours_deny": "Rechazar",
+  "extra_hours_failed": "¿Otra vez por aquí?",
+  "extra_hours_failed_body": "Ha ocurrido un error en la aceptación de horas extras. La aceptación o rechazo de estas horas extras ya ha sido realizada.",
+  "extra_hours_not_found": "Petición de horas extras no encontrada",
+  "extra_hours_found_body1": "Tu petición de horas extras no ha sido encontrada en el sistema. Si cree que ha sido un error, por favor póngase en contacto con el equipo de Brisbox. Si dispone de un cliente de correo, pulse en "
 }

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -316,9 +316,16 @@ Router.route('/order/:_id/finished', {
 
 
 
-Router.route('/acceptExtraHours', function () {
-    this.render('acceptExtraHours');
-}, {
+Router.route('/acceptExtraHours', {
+    template: 'acceptExtraHours',
+    waitOn: function () {
+        return subs.subscribe("extra_hoursAll");
+    },
+    data: function () {
+        var extraHoursIdDecodificado = Base64.decode(sessionStorage.get('extraHoursId'));
+        var extraHours = ExtraHours.find({_id: extraHoursIdDecodificado}).fetch()[0];
+        return extraHours;
+    },
     name: 'acceptExtraHours'
 });
 Router.route('/acceptExtraHoursFailed', function () {

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -318,12 +318,15 @@ Router.route('/order/:_id/finished', {
 
 Router.route('/acceptExtraHours', {
     template: 'acceptExtraHours',
-    waitOn: function () {
+    /*waitOn: function () {
         return subs.subscribe("extra_hoursAll");
-    },
+    },*/
     data: function () {
-        var extraHoursIdDecodificado = Base64.decode(sessionStorage.get('extraHoursId'));
-        var extraHours = ExtraHours.find({_id: extraHoursIdDecodificado}).fetch()[0];
+        var extraHours = "extraHoursNotFound";
+        if (sessionStorage.getItem('extraHoursId') != null) {
+            var extraHoursIdDecodificado = Base64.decode(sessionStorage.getItem('extraHoursId'));
+            extraHours = ExtraHours.find({_id: extraHoursIdDecodificado}).fetch()[0];
+        }
         return extraHours;
     },
     name: 'acceptExtraHours'

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -313,3 +313,26 @@ Router.route('/order/:_id/finished', {
     template: 'FinishedOrder',
     name: 'finished-order'
 });
+
+
+
+Router.route('/acceptExtraHours', function () {
+    this.render('acceptExtraHours');
+}, {
+    name: 'acceptExtraHours'
+});
+Router.route('/acceptExtraHoursFailed', function () {
+    this.render('acceptExtraHoursFailed');
+}, {
+    name: 'acceptExtraHoursFailed'
+});
+Router.route('/extraHoursNotFound', function () {
+    this.render('extraHoursNotFound');
+}, {
+    name: 'extraHoursNotFound'
+});
+Router.route('accept-extra-hours', {
+    controller: 'AcceptExtraHoursController',
+    path: '/accept-extra-hours/:id',
+    action: 'acceptExtraHours'
+});

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -318,9 +318,9 @@ Router.route('/order/:_id/finished', {
 
 Router.route('/acceptExtraHours', {
     template: 'acceptExtraHours',
-    /*waitOn: function () {
+    waitOn: function () {
         return subs.subscribe("extra_hoursAll");
-    },*/
+    },
     data: function () {
         var extraHours = "extraHoursNotFound";
         if (sessionStorage.getItem('extraHoursId') != null) {

--- a/server/methods.js
+++ b/server/methods.js
@@ -177,6 +177,22 @@ Meteor.methods({
         return res;
     },
 
+    'acceptExtraHours': function (extraHoursIdCodificado) {
+        var res = "NOTFOUND";
+        var extraHoursIdDecodificado = Base64.decode(extraHoursIdCodificado);
+        var extraHours = ExtraHours.findOne({"_id": extraHoursIdDecodificado});
+        if (ExtraHours.find({"_id":extraHoursIdDecodificado}).count() == 1) {
+            if (extraHours.accepted == "pending"){
+                res = "ACCEPT_EXTRA_HOURS";
+            } else if (extraHours.accepted == "accepted" || extraHours.accepted == "rejected"){
+                res = "ALREADY_CHOSED";
+            }
+        } else {
+            res = "NOTFOUND";
+        }
+        return res;
+    },
+
     'cancelOrder': function (orderIdCodificado, cancelationCode) {
         var res = false;
         var orderIdDecodificado = Meteor.call('deCodificaString', orderIdCodificado);

--- a/server/methods.js
+++ b/server/methods.js
@@ -177,7 +177,7 @@ Meteor.methods({
         return res;
     },
 
-    'acceptExtraHours': function (extraHoursIdCodificado) {
+    'acceptExtraHoursController': function (extraHoursIdCodificado) {
         var res = "NOTFOUND";
         var extraHoursIdDecodificado = Base64.decode(extraHoursIdCodificado);
         var extraHours = ExtraHours.findOne({"_id": extraHoursIdDecodificado});
@@ -191,6 +191,24 @@ Meteor.methods({
             res = "NOTFOUND";
         }
         return res;
+    },
+
+    'acceptExtraHours': function (extraHoursIdDecodificado) {
+        var extraHours = ExtraHours.findOne({"_id": extraHoursIdDecodificado});
+        ExtraHours.update(extraHoursIdDecodificado, {
+            $set: {
+                accepted: "accepted"
+            }
+        });
+    },
+
+    'rejectExtraHours': function (extraHoursIdDecodificado) {
+        var extraHours = ExtraHours.findOne({"_id": extraHoursIdDecodificado});
+        ExtraHours.update(extraHoursIdDecodificado, {
+            $set: {
+                accepted: "rejected"
+            }
+        });
     },
 
     'cancelOrder': function (orderIdCodificado, cancelationCode) {


### PR DESCRIPTION
## Resumen:

Se ha añadido la vista de aceptación de horas extras por parte del capitán del pedido, a la cual accederá desde la url facilitada en el email remitido (#209).
## Pruebas a realizar:

Se probará que la funcionalidad de aceptación/rechazo de las horas extras funciona correctamente, así como la respuesta a todos los casos de uso posibles:
-  Comprobar que la url del email lleva al sitio correcto, guardando en el data el extraHours que se quiere modificar.
- Comprobar que las horas mostradas en el botón de 'aceptar X horas extras' son correctas.
- Solo se puede acceder conociendo la id del extraHours creado en el proceso (la cual va en la url del email). Si se accede a /acceptExtraHours sin haber inicializado previamente el extraHours (lo cual se hace accediendo desde el enlace correcto, el facilitado en el email), debe mostrarse una pantalla de error, explicando los detalles.
- Igualmente si después de haber aceptado/rechazado la petición se vuelve atrás, debe aparecer la misma ventana de error.
- Si se accede al enlace del email de nuevo una vez resuelta la petición, debe mostrarse una pantalla que indique que esa petición ya ha sido resuelta previamente.
- Si se accede al enlace, pero el id del enlace no es correcto, debe mostrarse una ventana de error (ya que no se encuentra el extraHours en la bd).
- Una vez resuelta correctamente la petición, se debe redirigir a la vista del dashboard del order que se está tratando.
- Comprobar que el atributo accepted se modifica correctamente, tanto si se acepta (accepted=accepted) como si se rechaza (accepted=rejected).
## Incidencias:

No hay incidencias, salvo comentar que esta funcionalidad depende de otras que deben estar implementadas previamente. Realizar los test indicados previamente para asegurarse que no hay problemas de conflictos o variables llamadas de forma diferente en las distintas implementaciones.
